### PR TITLE
Reduce administrivia in README

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -1,0 +1,35 @@
+# Copyright and licensing
+
+Copyright © 2022 Daniel F. Dickinson
+
+## Textual and media content
+
+Except where otherwise noted, textual and media components in this repository
+are licensed under the Creative Commons Attribution Share-Alike 4.0
+International license. (Basically a 'share it forward' license).
+
+See [LICENSE-TEXT-MEDIA](LICENSE-TEXT-MEDIA) in this repository for
+that license.
+
+## Code and configuration
+
+Except where otherwise noted, and where applicable _([Note 1](#note-1))_, code
+and configurations in this repository are licensed under an MIT license.
+
+See [LICENSE-CODE-AND-CONFIGS](LICENSE-CODE-AND-CONFIGS) in this repository for
+that license.
+
+## Clarification
+
+For the purposes of this repository the word lists are 'config', and the
+[README.md](README.md) is textual.
+
+--------
+
+## Notes
+
+### Note 1
+
+Configurations are not particularly copyrightable anyway, nor do I particularly
+want to, but this makes it clear you can use them on an "AS-IS" basis (i.e.
+please don't sue me if they break or cause breakage).

--- a/README.md
+++ b/README.md
@@ -2,12 +2,22 @@
 
 Daniel's word lists for [CSpell][cspell] custom dictionaries.
 
-## Status
+## Metadata
+
+### Status
 
 [![pre-commit.ci
 status](https://results.pre-commit.ci/badge/github/danielfdickinson/dfd-wordlists/main.svg)](https://results.pre-commit.ci/latest/github/danielfdickinson/dfd-wordlists/main)
 
-## Currently includes
+### Demo and/or documentation site or page
+
+Not yet created: it may never be.
+
+### Repository URL
+
+<https://github.com/danielfdickinson/dfd-wordlists>
+
+## Featured word lists
 
 * [Technology (especially computing) words Daniel needs CSpell to recognize
 (words-tech.txt)](words-tech.txt)
@@ -205,59 +215,18 @@ configuration, one uses a URL (e.g.
 Use `cspell --config tests/config/cspell.json …` (that is, with any additional
 command line parameters, not literally `…`) from the root of your project.
 
-## Copyright and licensing
+## Getting help, discussing, and/or modifying
 
-Copyright © 2022 Daniel F. Dickinson
-
-### Textual and media content
-
-Except where otherwise noted, textual and media components in this repository
-are licensed under the Creative Commons Attribution Share-Alike 4.0
-International license. (Basically a 'share it forward' license).
-
-See [LICENSE-TEXT-MEDIA](LICENSE-TEXT-MEDIA) in this repository for
-that license.
-
-### Code and configuration
-
-Except where otherwise noted, and where applicable _([Note 2](#note-2))_, code
-and configurations in this repository are licensed under an MIT license.
-
-See [LICENSE-CODE-AND-CONFIGS](LICENSE-CODE-AND-CONFIGS) in this repository for
-that license.
-
-### Acknowledgements
-
-Thank you to '@davidsneighbour' for introducing me to
-[pre-commit](https://pre-commit.com) and whose configurations I have gleefully
-extended (for example adding [CSpell][cspell] for spell checking).
-
-Thank you to '@brycewray' for writing an excellent [article on the
-accessibility argument for tabs vs spaces in code][tabaccess]. Hopefully I
-haven't taken that _too_ far (_[Note 1](#note-1)_).
+* [Support and general questions](docs/SUPPORT.md)
+* [Bugs and feature requests](docs/SUPPORT.md)
+* [Contributing modifications to the repository](docs/CONTRIBUTING.md)
 
 -------
 
-## Notes
+## Colophon
 
-### Note 1
-
-Uses EditorConfig for an editor neutral default styling
-
-* Defaults to [using tabs where possible for accessibility
-reasons][tabaccess]
-* `root = false` so that the user can set their preferred (or required for
-accessibility reasons) rendering of the tabs via a `.editorconfig` file in
-a higher level directory, or their home directory. Not doing this defeats
-the purpose of using tabs vs. spaces.
-* `tab_width` is **not** set in this repository so that the user's config
-will be used. (See above).
-
-### Note 2
-
-Configurations are not particularly copyrightable anyway, nor do I particularly
-want to, but this makes it clear you can use them on an "AS-IS" basis (i.e.
-please don't sue me if they break or cause breakage).
+* [Copyright and licensing](COPYING.md)
+* [Inspirations, information, and source material](docs/ACKNOWLEDGEMENTS.md)
+* [Notes](docs/README-NOTES.md)
 
 [cspell]: https://cspell.org
-[tabaccess]: https://www.brycewray.com/posts/2022/06/accessibility-argument-tabs-spaces/

--- a/docs/ACKNOWLEDGEMENTS.md
+++ b/docs/ACKNOWLEDGEMENTS.md
@@ -1,0 +1,16 @@
+# Acknowledgements
+
+## Thank you
+
+* '@davidsneighbour' for introducing me to [pre-commit][precommit] and whose
+configurations I have gleefully extended (for example adding
+[CSpell][cspell] for spell checking).
+* '@brycewray' for writing an excellent [article on the accessibility argument
+for tabs vs spaces in code][tabaccess]. Hopefully I haven't taken that _too_
+far (_[Note 1](README-NOTES.md#note-1)_).
+
+--------
+
+[cspell]: https://cspell.org
+[precommit]: https://pre-commit.com
+[tabaccess]: https://www.brycewray.com/posts/2022/06/accessibility-argument-tabs-spaces/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+Please [check for open issues][open-issues] for enhancements and
+bugs that you would like resolved, write the solution, and submit a
+Pull Request!
+
+Alternatively, if [your bug or feature request can't be found when searching
+both open and closed issues][issues], please create a new issue, and if you
+can, create a Pull Request as mentioned in the paragraph above.
+
+Adding and improving documentation is always welcomed, as well.
+
+[issues]: https://github.com/danielfdickinson/dfd-wordlists/issues?q=is%3Aissue
+[open-issues]: https://github.com/danielfdickinson/dfd-wordlists/issues?q=is%3Aissue+is%3Aopen

--- a/docs/README-NOTES.md
+++ b/docs/README-NOTES.md
@@ -1,0 +1,43 @@
+# Notes
+
+## Note 1
+
+Uses [EditorConfig][edconf] for an editor neutral default styling
+
+* Defaults to [using tabs where possible for accessibility
+reasons][tabaccess]
+* `root = false` so that the user can set their preferred (or required for
+accessibility reasons) rendering of the tabs via a `.editorconfig` file in
+a higher level directory, or their home directory. Not doing this defeats
+the purpose of using tabs vs. spaces.
+* `tab_width` is **not** set in this repository so that the user's config
+will be used. (See above).
+
+## Note 2
+
+'We' is the 'royal we' (because we don't like saying 'I' a lot and often we
+want speak in the first person), and 'I' am
+[@danielfdickinson](https://github.com/danielfdickinson).
+
+## Note 3
+
+This repository uses [pre-commit][precommit] to filter out (and potentially
+auto-fix) issues with many minor (and some not so minor) 'nits'.
+
+The developer who introduced me to pre-commit has written [a blog post giving
+some context and general information on the use
+of
+'pre-commit'][dnbprecommit],
+and the official docs are pretty good too, so perhaps that will suffice.
+
+He prefers a different code spell checker though, but [the README for the word
+lists I use with CSpell][dfdwordsdoc] has some info on [CSpell][cspell].
+
+--------
+
+[cspell]: https://cspell.org
+[dfdwordsdoc]: ../README.md
+[dnbprecommit]: https://kollitsch.dev/blog/2022/simple-multi-language-pre-commit-hooks/
+[edconf]: https://editorconfig.org/
+[precommit]: https://pre-commit.com
+[tabaccess]: https://www.brycewray.com/posts/2022/06/accessibility-argument-tabs-spaces/

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,14 @@
+# Support options
+
+1. Check the [README.md](../README.md)
+2. Try [Discussions for support and general questions][discussions]
+3. If [your bug or feature request can't be found when searching both open
+and closed issues][issues], please create a new issue.
+4. For matters which require privacy, please use [my published email
+address][dfdmail]
+
+--------
+
+[discussions]: https://github.com/danielfdickinson/dfd-wordlists/discussions
+[dfdmail]: mailto:dfdpublic@wildtechgarden.ca
+[issues]: https://github.com/danielfdickinson/dfd-wordlists/issues?q=is%3Aissue

--- a/words-dfd.txt
+++ b/words-dfd.txt
@@ -202,6 +202,7 @@ Zebest
 Zeldon
 Zeneca
 Zyprexa
+administrivia
 aideraan
 akinesia
 analyzed


### PR DESCRIPTION
By splitting it out into the `docs` directory, and a COPYING.md file
(for copyright and licensing overview). This as the bonus that we get
two repo-specific GitHub 'community health' files (CONTRIBUTING and
SUPPORT).

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>